### PR TITLE
Add ability to enable/disable tilt-to-wake.

### DIFF
--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1250,6 +1250,11 @@ static const setting_t gconf_defaults[] =
     .def  = G_STRINGIFY(MCE_DEFAULT_FLIPOVER_GESTURE_ENABLED),
   },
   {
+    .key  = MCE_SETTING_WRIST_GESTURE_ENABLED,
+    .type = "b",
+    .def  = G_STRINGIFY(MCE_DEFAULT_WRIST_GESTURE_ENABLED),
+  },
+  {
     .key  = MCE_SETTING_ORIENTATION_CHANGE_IS_ACTIVITY,
     .type = "b",
     .def  = G_STRINGIFY(MCE_DEFAULT_ORIENTATION_CHANGE_IS_ACTIVITY),

--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1255,6 +1255,11 @@ static const setting_t gconf_defaults[] =
     .def  = G_STRINGIFY(MCE_DEFAULT_WRIST_GESTURE_ENABLED),
   },
   {
+    .key  = MCE_SETTING_WRIST_GESTURE_AVAILABLE,
+    .type = "i",
+    .def  = G_STRINGIFY(MCE_DEFAULT_WRIST_GESTURE_AVAILABLE),
+  },
+  {
     .key  = MCE_SETTING_ORIENTATION_CHANGE_IS_ACTIVITY,
     .type = "b",
     .def  = G_STRINGIFY(MCE_DEFAULT_ORIENTATION_CHANGE_IS_ACTIVITY),

--- a/modules/display.h
+++ b/modules/display.h
@@ -174,9 +174,14 @@
 # define MCE_SETTING_ORIENTATION_CHANGE_IS_ACTIVITY      MCE_SETTING_DISPLAY_PATH "/orientation_change_is_activity"
 # define MCE_DEFAULT_ORIENTATION_CHANGE_IS_ACTIVITY      false
 
-/** Whether MCE is allowed to use orientation sensor */
-# define MCE_SETTING_WRIST_GESTURE_ENABLED          MCE_SETTING_DISPLAY_PATH "/wrist_sensor_enabled"
-# define MCE_DEFAULT_WRIST_GESTURE_ENABLED          true
+/** Whether MCE is allowed to use wrist gesture sensor */
+# define MCE_SETTING_WRIST_GESTURE_ENABLED              MCE_SETTING_DISPLAY_PATH "/wrist_sensor_enabled"
+# define MCE_DEFAULT_WRIST_GESTURE_ENABLED              true
+
+/** Whether the wrist gesture sensor is available on the hardware */
+# define MCE_SETTING_WRIST_GESTURE_AVAILABLE            MCE_SETTING_DISPLAY_PATH "/wrist_sensor_available"
+# define MCE_DEFAULT_WRIST_GESTURE_AVAILABLE            1
+
 
 
 /* ------------------------------------------------------------------------- *

--- a/modules/display.h
+++ b/modules/display.h
@@ -174,6 +174,11 @@
 # define MCE_SETTING_ORIENTATION_CHANGE_IS_ACTIVITY      MCE_SETTING_DISPLAY_PATH "/orientation_change_is_activity"
 # define MCE_DEFAULT_ORIENTATION_CHANGE_IS_ACTIVITY      false
 
+/** Whether MCE is allowed to use orientation sensor */
+# define MCE_SETTING_WRIST_GESTURE_ENABLED          MCE_SETTING_DISPLAY_PATH "/wrist_sensor_enabled"
+# define MCE_DEFAULT_WRIST_GESTURE_ENABLED          true
+
+
 /* ------------------------------------------------------------------------- *
  * Color profile related settings
  * ------------------------------------------------------------------------- */

--- a/tools/mcetool.c
+++ b/tools/mcetool.c
@@ -3439,6 +3439,29 @@ static void xmce_get_orientation_change_is_activity(void)
         printf("%-"PAD1"s %s\n", "Orientation change is activity:", txt);
 }
 
+/** Set wrist gesture detection toggle
+ *
+ * @param args string suitable for interpreting as enabled/disabled
+ */
+static bool xmce_set_wrist_gesture_detection(const char *args)
+{
+        gboolean val = xmce_parse_enabled(args);
+        xmce_setting_set_bool(MCE_SETTING_WRIST_GESTURE_ENABLED, val);
+        return true;
+}
+
+/** Show wrist gesture detection toggle
+ */
+static void xmce_get_wrist_gesture_detection(void)
+{
+        gboolean val = 0;
+        char txt[32] = "unknown";
+
+        if( xmce_setting_get_bool(MCE_SETTING_WRIST_GESTURE_ENABLED, &val) )
+                snprintf(txt, sizeof txt, "%s", val ? "enabled" : "disabled");
+        printf("%-"PAD1"s %s\n", "Wrist tilt gesture detection:", txt);
+}
+
 /** Set flipover gesture detection toggle
  *
  * @param args string suitable for interpreting as enabled/disabled
@@ -5538,6 +5561,7 @@ static bool xmce_get_status(const char *args)
         xmce_get_orientation_sensor_mode();
         xmce_get_orientation_change_is_activity();
         xmce_get_flipover_gesture_detection();
+        xmce_get_wrist_gesture_detection();
         xmce_get_ps_mode();
         xmce_get_ps_blocks_touch();
         xmce_get_ps_acts_as_lid();
@@ -6462,6 +6486,14 @@ static const mce_opt_t options[] =
                 .with_arg    = xmce_set_flipover_gesture_detection,
                 .values      = "enabled|disabled",
                         "set the flipover gesture detection toggle; valid modes are:\n"
+                        "  'enabled'  flipover gestures can be used to silence calls/alarms\n"
+                        "  'disabled' turning device over does not affect calls/alarms\n"
+        },
+        {
+                .name        = "set-wrist-gesture-detection",
+                .with_arg    = xmce_set_wrist_gesture_detection,
+                .values      = "enabled|disabled",
+                        "set the wrist gesture detection toggle; valid modes are:\n"
                         "  'enabled'  flipover gestures can be used to silence calls/alarms\n"
                         "  'disabled' turning device over does not affect calls/alarms\n"
         },


### PR DESCRIPTION
This adds an option to enable/disable tilt-to-wake from dbus and the mcetool.

This is needed for the asteroid-settings PR to work(https://github.com/AsteroidOS/asteroid-settings/pull/23).