### PR TITLE
sensorfw: Reserve gesture for tilt-to-wake.

### DIFF
--- a/evdev.h
+++ b/evdev.h
@@ -28,6 +28,7 @@ typedef enum {
        GESTURE_SWIPE_FROM_BOTTOM = 3,
        GESTURE_DOUBLETAP         = 4, /* To conform with value used in
                                       * Nokia N9 kernel driver */
+       GESTURE_TILT_TO_WAKE      = 5,
 } gesture_t;
 
 const char *evdev_get_event_code_name(int etype, int ecode);

--- a/mce-sensorfw.c
+++ b/mce-sensorfw.c
@@ -3732,12 +3732,11 @@ sfw_notify_wrist(sfw_notify_t type, bool input_value)
 
     ev = malloc(sizeof(struct input_event));
 
-    mce_log(LL_CRUCIAL, "[longpress] double tap emulated from wrist gesture");
-    mce_log(LL_DEVEL, "[longpress] double tap emulated from wrist gesture");
+    mce_log(LL_DEVEL, "tilt-to-wake gesture from wrist gesture");
 
     ev->type  = EV_MSC;
     ev->code  = MSC_GESTURE;
-    ev->value = GESTURE_DOUBLETAP;
+    ev->value = GESTURE_TILT_TO_WAKE;
  
     evin_iomon_generate_activity(ev, true, true);
 


### PR DESCRIPTION
Assign gesture 5 for use with tilt-to-wake, instead of gesture 4 (GESTURE_DOUBLETAP).
This adds the ability to disable tap-to-wake while keeping tilt-to-wake enabled.

A separate setting needs to be added in asteroid-settings(https://github.com/MagneFire/asteroid-settings/commits/tap-to-wake). Ill create a PR for that once the other PR is closed(https://github.com/AsteroidOS/asteroid-settings/pull/27).

Here is a preview of the new setting looks like.
![Screenshot_20200824_185023](https://user-images.githubusercontent.com/7857908/91073376-4139fe00-e63b-11ea-812f-2eee5017cba1.jpg)

This feature was suggested by @hummlbach and @eLtMosen.